### PR TITLE
fix: change python-* packages to python3-*

### DIFF
--- a/tasks/install-hassio.yml
+++ b/tasks/install-hassio.yml
@@ -30,6 +30,7 @@
     name: hassio-apparmor
     state: restarted
     daemon_reload: true
+    enabled: yes
   when: AppArmor_conf.changed
 
 - name: Copy HASSIO Service
@@ -44,6 +45,7 @@
     name: hassio-supervisor
     state: restarted
     daemon_reload: true
+    enabled: yes
   when: supervisor_conf.changed
 
 - name: Install the 'ha' cli

--- a/tasks/setup-pre.yml
+++ b/tasks/setup-pre.yml
@@ -6,8 +6,8 @@
       - curl
       - jq
       - network-manager
-      - python-docker
-      - python-pip
+      - python3-docker
+      - python3-pip
     state: present
 
 - name: pip docker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Debian changed the package names for the python-docker package and after buster this role does no longer work.
This PR simply changes these dependency package names. Probably won't break anything seeing `python3-docker` existed back in Stretch too.

## Related issues
#2 

## Motivation and Context
Working on something that requires me to use Ansible for a Hassio installation, might as well contribute my changes to make it work.

## How has this been tested
Tested in a packer setup with a clean Debian 11 install, first installing docker using the `geerlingguy.docker` role.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [ ] Breaking change (fix or feature that would cause existing functionality to change/break).



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/totaldebug/.github/blob/master/docs/CONTRIBUTING.md) document.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.
